### PR TITLE
Add Gemini-based narrative NPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This plugin provides a set of tools to create custom and complex behaviour in th
 - Editor Interface with shortcuts
 - [Templates](docs/documentation.md#using-script-templates) for easy extension and integration
 - Example Scene
+- Narrative NPCs via Gemini Flash API (experimental)
 
 When a new version is available on GitHub, the plugin will display a notification in the Toolbox! 
 

--- a/addons/behaviour_toolkit/narrative/narrative_npc.gd
+++ b/addons/behaviour_toolkit/narrative/narrative_npc.gd
@@ -1,0 +1,60 @@
+@tool
+class_name NarrativeNPC extends Node
+## Node that uses the Gemini Flash API for conversational NPCs.
+
+signal reply_received(reply: String)
+
+@export var api_key: String = ""
+@export var persona_prompt: String = "You are a helpful villager."
+@export var model_url: String = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key="
+@export var temperature: float = 0.5
+
+var _conversation: Array = []
+var _request: HTTPRequest
+
+func _ready():
+        _request = HTTPRequest.new()
+        add_child(_request)
+        _request.connect("request_completed", _on_request_completed)
+
+func ask(message: String) -> void:
+        if api_key == "":
+                BehaviourToolkit.Logger.say(
+                        "No Gemini API key provided.",
+                        self,
+                        BehaviourToolkit.LogType.ERROR
+                )
+                return
+
+        _conversation.append({"role": "user", "text": message})
+
+        var messages: Array = []
+        if persona_prompt != "":
+                messages.append({"parts": [{"text": persona_prompt}]})
+        for entry in _conversation:
+                messages.append({"parts": [{"text": entry.text}]})
+
+        var data := {
+                "contents": messages,
+                "generationConfig": {"temperature": temperature}
+        }
+        var json_payload = JSON.stringify(data)
+        var headers := ["Content-Type: application/json"]
+        var url = model_url + api_key
+        _request.request(url, headers, HTTPClient.METHOD_POST, json_payload)
+
+func _on_request_completed(result:int, response_code:int, headers:PackedStringArray, body:PackedByteArray) -> void:
+        if result != OK:
+                BehaviourToolkit.Logger.say(
+                        "Gemini request failed with result %s" % result,
+                        self,
+                        BehaviourToolkit.LogType.ERROR
+                )
+                return
+
+        var response = JSON.parse_string(body.get_string_from_utf8())
+        if response is Dictionary and response.has("candidates"):
+                var candidate = response["candidates"][0]
+                var reply := candidate["content"]["parts"][0]["text"]
+                _conversation.append({"role": "model", "text": reply})
+                emit_signal("reply_received", reply)

--- a/addons/behaviour_toolkit/narrative/narrative_npc.gd.uid
+++ b/addons/behaviour_toolkit/narrative/narrative_npc.gd.uid
@@ -1,0 +1,1 @@
+uid://fisu3f7ywcui

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -314,3 +314,6 @@ This example is a very messy implementation of the BehaviourToolkit and is only 
   - You can revive them by clicking on them, which will leave the State Machine and return them to their normal behaviour.
 
 There also is a seperate `FiniteStateMachine` used for handling simple animations.
+
+## Example: Narrative NPC
+`narrative_npc.gd` demonstrates how to connect an NPC to Google's Gemini Flash API for dialogue. The node exposes an `ask()` function which sends text to the API and emits `reply_received` when the model answers. You must provide your own API key and should note that the service is not moderated and may produce offensive or inaccurate content.


### PR DESCRIPTION
## Summary
- implement a `NarrativeNPC` node that connects to Google's Gemini Flash API
- document the new experimental feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884c32bb8708323a9a35594ac957cd5